### PR TITLE
Appeal to Authority

### DIFF
--- a/web/premises/fallacies.json
+++ b/web/premises/fallacies.json
@@ -20,4 +20,5 @@
     ["Argument To Pity", "Duygu Sömürüsü"],
     ["Prejudicial Language", "Önyargılı Dil Safsatası"],
     ["Fallacy Of Special Pleading", "Mazeret Safsatası"]
+    ["Appeal To Authority", "Bir Bilen Safsatası"]
 ]


### PR DESCRIPTION
Adding "Appeal to Authority" as a fallacy type. It is one of the most common logical fallacies, yet it didn't exist on argumanorg. Safsata Kilavuzu translated it as "Bir Bilen Safsatasi".
