### PR TITLE
clean: remove pgsql requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 Django==1.7
-psycopg2==2.6.1
 Unidecode==0.04.16
 django-social-auth==0.7.28
 httplib2==0.9


### PR DESCRIPTION
This dependance doesn't seem to be relevant regarding the stack (Redis + MongoDB). Also it makes `vagrant up` to fail as postgres is not installed.