### PR TITLE
Update fallacies.json

### DIFF
--- a/web/premises/fallacies.json
+++ b/web/premises/fallacies.json
@@ -8,7 +8,7 @@
     ["Fallacy Of The Beard", "Devede Kulak Safsatası"],
     ["Fallacy of Slippery Slope", "Felaket Tellallığı Safsatası"],
     ["Fallacy of False Cause", "Yanlış Sebep Safsatası"],
-    ["Fallacy of “Previous This”", "Öncesinde Safsatası"],
+    ["Post Hoc Ergo Propter Hoc", "Öncesinde Safsatası"],
     ["Joint Effect", "Müşterek Etki"],
     ["Wrong Direction", "Yanlış Yön Safsatası"],
     ["False Analogy", "Yanlış Benzetme Safsatası"],


### PR DESCRIPTION
Most of the global logic community calls the fallacy "post hoc ergo propter hoc", shortened to either "post hoc fallacy" or "causalation". I know you're based in the Turkish-speaking community and all, but I never see "previous this" unless it's adjacent to its Turkish name and usually also the Latin name familiar to logicians around the world. And on the Anglophone-facing version of the site it is best to reflect a universal consensus on the name.
