### PR TITLE
only redirect to translated page if the site is configured to do so

### DIFF
--- a/web/premises/views.py
+++ b/web/premises/views.py
@@ -92,10 +92,10 @@ class ContentionDetailView(DetailView):
         self.object = self.get_object()
         host = request.META['HTTP_HOST']
 
-        if not host.startswith(settings.AVAILABLE_LANGUAGES):
+        if not settings.PREVENT_LANGUAGE_REDIRECTION and not host.startswith(settings.AVAILABLE_LANGUAGES):
             return redirect(self.object.get_full_url(), permanent=True)
 
-        if not normalize_language_code(get_language()) == self.object.language:
+        if not settings.PREVENT_LANGUAGE_REDIRECTION and not normalize_language_code(get_language()) == self.object.language:
             return redirect(self.object.get_full_url(), permanent=True)
 
         partial = request.GET.get('partial')


### PR DESCRIPTION
This resolves an issue whereby the `PREVENT_LANGUAGE_REDIRECTION` setting would allow users to create new arguments, but all attempts to view detail pages would redirect to non-existent translation pages.
