### PR TITLE
Fix #351 Make adding channels easier

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ httplib2==0.9
 oauth2==1.5.211
 python-openid==2.2.5
 wsgiref==0.1.2
+django-admin-sortable2~=0.6.15
 django-gravatar2==1.1.4
 django-extensions==1.6.1
 markdown2==2.3.0

--- a/web/main/settings.py
+++ b/web/main/settings.py
@@ -1,3 +1,4 @@
+# -*- coding: UTF-8 -*-
 """
 Django settings for arguman project.
 
@@ -42,7 +43,9 @@ INSTALLED_APPS = (
 
     'typogrify',
     'social_auth',
+    'adminsortable2',
     'django_gravatar',
+    'django_extensions',
     'rest_framework',
     'rest_framework.authtoken',
     'profiles',
@@ -102,12 +105,14 @@ DEFAULT_LANGUAGE = 'en'
 
 BASE_DOMAIN = 'arguman.org'
 
-AVAILABLE_LANGUAGES = (
-    'tr',
-    'en',
-    'ch',
-    'fr'
+LANGUAGES = (
+    ('tr', u'Türkçe'),
+    ('en', u'English'),
+    ('ch', u'中文'),
+    ('fr', u'Français')
 )
+
+AVAILABLE_LANGUAGES = [lang_code for lang_code, lang_name in LANGUAGES]
 
 LANGUAGE_CODE_MAPPING = {
     'ch': 'zh-Hans'

--- a/web/nouns/admin.py
+++ b/web/nouns/admin.py
@@ -1,3 +1,5 @@
+from adminsortable2.admin import SortableAdminMixin
+
 from django.contrib import admin
 from django.db.models import Q
 from django.http import HttpResponseRedirect
@@ -110,8 +112,9 @@ class NounAdmin(ActionInChangeFormMixin, admin.ModelAdmin):
         return qs.update(is_active=False)
 
 
-class ChannelAdmin(admin.ModelAdmin):
+class ChannelAdmin(SortableAdminMixin, admin.ModelAdmin):
     filter_horizontal = ('nouns', )
+    exclude = ('order',)
 
 
 admin.site.register(Noun, NounAdmin)

--- a/web/nouns/migrations/0019_draggable_reoder_plus_verbal_language_choices.py
+++ b/web/nouns/migrations/0019_draggable_reoder_plus_verbal_language_choices.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import django.utils.translation
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('nouns', '0018_channel_is_featured'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='channel',
+            options={'ordering': ('order',)},
+        ),
+        migrations.AlterField(
+            model_name='channel',
+            name='is_featured',
+            field=models.BooleanField(default=False, help_text='If set this channel will be shown on the main page', max_length=255),
+        ),
+        migrations.AlterField(
+            model_name='channel',
+            name='language',
+            field=models.CharField(default=django.utils.translation.get_language, max_length=255, choices=[(b'tr', 'T\xfcrk\xe7e'), (b'en', 'English'), (b'ch', '\u4e2d\u6587'), (b'fr', 'Fran\xe7ais')]),
+        ),
+        migrations.AlterField(
+            model_name='channel',
+            name='order',
+            field=models.IntegerField(default=0),
+        ),
+        migrations.AlterField(
+            model_name='noun',
+            name='language',
+            field=models.CharField(default=django.utils.translation.get_language, max_length=25, choices=[(b'tr', 'T\xfcrk\xe7e'), (b'en', 'English'), (b'ch', '\u4e2d\u6587'), (b'fr', 'Fran\xe7ais')]),
+        ),
+    ]

--- a/web/nouns/models.py
+++ b/web/nouns/models.py
@@ -1,7 +1,6 @@
 from uuid import uuid4
 from unidecode import unidecode
 
-from adminsortable.models import SortableMixin
 from django.db import models
 from django.utils.encoding import smart_unicode
 from django.conf import settings

--- a/web/nouns/models.py
+++ b/web/nouns/models.py
@@ -4,7 +4,6 @@ from unidecode import unidecode
 from adminsortable.models import SortableMixin
 from django.db import models
 from django.utils.encoding import smart_unicode
-from django.utils.translation import get_language
 from django.conf import settings
 from django.template.defaultfilters import slugify
 from django.utils.functional import curry

--- a/web/nouns/models.py
+++ b/web/nouns/models.py
@@ -1,8 +1,10 @@
 from uuid import uuid4
 from unidecode import unidecode
 
+from adminsortable.models import SortableMixin
 from django.db import models
 from django.utils.encoding import smart_unicode
+from django.utils.translation import get_language
 from django.conf import settings
 from django.template.defaultfilters import slugify
 from django.utils.functional import curry
@@ -16,7 +18,7 @@ from nouns.utils import get_synsets, get_lemmas, from_lemma
 class Noun(models.Model):
     text = models.CharField(max_length=255, db_index=True)
     slug = models.SlugField(max_length=255, blank=True)
-    language = models.CharField(max_length=25)
+    language = models.CharField(max_length=25, choices=settings.LANGUAGES, default=get_language)
     is_active = models.BooleanField(default=True)
 
     class Meta:
@@ -209,12 +211,16 @@ class Relation(models.Model):
 
 
 class Channel(models.Model):
+    class Meta:
+        ordering = ('order',)
+
     title = models.CharField(max_length=255)
     slug = models.CharField(max_length=255)
     nouns = models.ManyToManyField('Noun', null=True, blank=True)
-    order = models.IntegerField()
-    language = models.CharField(max_length=255, blank=True, null=True)
-    is_featured = models.BooleanField(max_length=255, default=False)
+    order = models.IntegerField(default=0)
+    language = models.CharField(max_length=255, choices=settings.LANGUAGES, default=get_language)
+    # Translators: this is a Channel's is_featured field
+    is_featured = models.BooleanField(max_length=255, default=False, help_text=_('If set this channel will be shown on the main page'))
 
     def save(self, *args, **kwargs):
         if not self.slug:

--- a/web/premises/migrations/0038_verbal_language_choices.py
+++ b/web/premises/migrations/0038_verbal_language_choices.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('premises', '0037_missing_migrations'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='contention',
+            name='language',
+            field=models.CharField(max_length=5, null=True, choices=[(b'tr', 'T\xfcrk\xe7e'), (b'en', 'English'), (b'ch', '\u4e2d\u6587'), (b'fr', 'Fran\xe7ais')]),
+        ),
+    ]

--- a/web/premises/models.py
+++ b/web/premises/models.py
@@ -90,9 +90,7 @@ class Contention(DeletePreventionMixin, models.Model):
     date_creation = models.DateTimeField(auto_now_add=True)
     date_modification = models.DateTimeField(auto_now_add=True)
     ip_address = models.CharField(max_length=255, null=True, blank=True)
-    language = models.CharField(max_length=5, null=True,
-                                choices=[(language, language) for language in
-                                         settings.AVAILABLE_LANGUAGES])
+    language = models.CharField(max_length=5, null=True, choices=settings.LANGUAGES)
     nouns = models.ManyToManyField('nouns.Noun', blank=True, null=True,
                                    related_name="contentions")
     related_nouns = models.ManyToManyField('nouns.Noun', blank=True, null=True,

--- a/web/static/css/main.css
+++ b/web/static/css/main.css
@@ -3678,3 +3678,17 @@ div.load-more {
     height: 200px;
     border-radius: 50%;
 }
+
+.wcag_hide {
+   position:absolute;
+   top:0;
+   left:-10000px;
+   width:1px;
+   height:1px;
+}
+
+.wcag_hide2 {
+    clip: rect(1px, 1px, 1px, 1px);
+    display: block;
+    position: absolute;
+}

--- a/web/templates/partials/channel_list.html
+++ b/web/templates/partials/channel_list.html
@@ -1,11 +1,15 @@
 {% load i18n %}
-{% if channels.exists %}
+{% trans "Add channel" as add_channel %}
+{% if channels.exists or user.is_superuser %}
 <ul class="channel-list">
    {% for item in channels %}
        {% if item.is_featured %}
         <li{% if item == channel %} class="active"{% endif %}><a href="{{ item.get_absolute_url }}">{{ item }}</a></li>
        {% endif %}
    {% endfor %}
+    {% if user.is_superuser %}
+        <li><a title="{{ add_channel }}" href="{% url 'admin:nouns_channel_add' %}">+<span class="wcag_hide">{{ add_channel }}</span></a></li>
+    {% endif %}
     <li class="show-all-channels"><a href="#">{% trans "all channels" %}</a></li>
 </ul>
 


### PR DESCRIPTION
Changelog:
- showing channels bar on homepage for admins even if there are no channels
- added + sign (with WCAG message) on a channels bar to link to channel creation
- Channel's language is a mandatory field now
- Channel's and Noun's language is prefilled with current language
- Channel's order field has been hidden and drag-and-drop interface has been introduced by adminsortable2 library
- New translation: Hint for Channel's is_featured has been added
- WCAG "hide element" classes been added to css