### PR TITLE
Add missing requirement psycopg2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ anora==0.1.2
 snowballstemmer==1.2.0
 django-typogrify==1.3.2
 networkx==1.11
+psycopg2==2.7.5


### PR DESCRIPTION
psycopg2 is missing from the requirements.txt file