### PR TITLE
 X-Forwarded-For allows spoofing client IP address

### DIFF
--- a/web/premises/views.py
+++ b/web/premises/views.py
@@ -39,8 +39,7 @@ from i18n.utils import normalize_language_code
 
 
 def get_ip_address(request):
-    return (request.META.get('HTTP_X_FORWARDED_FOR') or
-            request.META.get('REMOTE_ADDR'))
+    return request.META.get('REMOTE_ADDR')
 
 
 class ContentionDetailView(DetailView):


### PR DESCRIPTION
Hi,

"X-Forwarded-For" does not validate IP addresses given as headers. Ip addresses that saved in database, may not be real.

Thanks! :+1: :100: 